### PR TITLE
Add matrix type aliases to prelude

### DIFF
--- a/examples/cornusammonis/3d-colorspace-projection.wgsl
+++ b/examples/cornusammonis/3d-colorspace-projection.wgsl
@@ -1,7 +1,5 @@
 #storage atomic_storage array<atomic<i32>>
 
-alias float4x4 = mat4x4<f32>;
-
 fn rotXW(t: float) -> float4x4 {
     return float4x4(
         1.0, 0.0, 0.0, 0.0,

--- a/examples/davidar/boids-predation-4d.wgsl
+++ b/examples/davidar/boids-predation-4d.wgsl
@@ -35,8 +35,6 @@ fn normz(v: float4) -> float4 {
 // particle rendering code based on "3D atomic rasterizer" by michael0884
 // https://compute.toys/view/21
 
-alias float3x3 = mat3x3<f32>;
-
 struct Camera {
     pos: float3,
     cam: float3x3,

--- a/examples/davidar/neighbourhood-grid.wgsl
+++ b/examples/davidar/neighbourhood-grid.wgsl
@@ -62,8 +62,6 @@ fn normz(v: float3) -> float3 {
 // particle rendering code based on "3D atomic rasterizer" by michael0884
 // https://compute.toys/view/21
 
-alias float3x3 = mat3x3<f32>;
-
 struct Camera {
     pos: float3,
     cam: float3x3,

--- a/examples/michael0884/3d-atomic-rasterizer.wgsl
+++ b/examples/michael0884/3d-atomic-rasterizer.wgsl
@@ -13,8 +13,6 @@ const DEPTH_MIN = 0.2;
 const DEPTH_MAX = 5.0;
 const DEPTH_BITS = 16u;
 
-alias float3x3 = mat3x3<f32>;
-
 struct Camera
 {
   pos: float3,

--- a/examples/michael0884/accretion-disk-simulation.wgsl
+++ b/examples/michael0884/accretion-disk-simulation.wgsl
@@ -2,9 +2,6 @@
 
 #storage atomic_storage array<atomic<i32>>
 
-alias float3x3 = mat3x3<f32>;
-alias float4x4 = mat4x4<f32>;
-
 struct Camera
 {
   pos: float3,

--- a/examples/michael0884/black-hole-particles.wgsl
+++ b/examples/michael0884/black-hole-particles.wgsl
@@ -13,9 +13,6 @@ const DEPTH_BITS = 16u;
 const dq = float2(0.0, 1.0);
 const eps = 0.01;
 
-alias float3x3 = mat3x3<f32>;
-alias float4x4 = mat4x4<f32>;
-
 struct Camera
 {
   pos: float3,

--- a/examples/michael0884/forward-volumetric-path-tracer.wgsl
+++ b/examples/michael0884/forward-volumetric-path-tracer.wgsl
@@ -7,9 +7,6 @@ const TWO_PI = 6.28318530718;
 const STEP = 0.01;
 const LARGENUM = 1e10;
 
-alias float3x3 = mat3x3<f32>;
-alias float2x2 = mat2x2<f32>;
-
 alias distanceArr = array<float,8>;
 
 struct Camera

--- a/examples/michael0884/stardust.wgsl
+++ b/examples/michael0884/stardust.wgsl
@@ -11,8 +11,6 @@ const DEPTH_MIN = 0.2;
 const DEPTH_MAX = 5.0;
 const DEPTH_BITS = 16u;
 
-alias float3x3 = mat3x3<f32>;
-
 struct Camera
 {
   pos: float3,

--- a/examples/michael0884/waves-around-a-black-hole.wgsl
+++ b/examples/michael0884/waves-around-a-black-hole.wgsl
@@ -8,9 +8,6 @@ struct SimData
     data: array<array<array<vec4<f32>, LENGTH>, LENGTH>,2>,
 }
 
-alias float3x3 = mat3x3<f32>;
-alias float4x4 = mat4x4<f32>;
-
 #storage sim SimData
 #define ITERATIONS 32
 #define SIM_FRAME (uint(ITERATIONS)*time.frame+dispatch.id)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -323,8 +323,15 @@ impl WgpuToyRenderer {
         let mut s = String::new();
         for (a, t) in [("int", "i32"), ("uint", "u32"), ("float", "f32")] {
             s.push_str(&format!("alias {a} = {t};\n"));
-            for n in [2, 3, 4] {
+        }
+        for (a, t) in [("int", "i32"), ("uint", "u32"), ("float", "f32"), ("bool", "bool")] {
+            for n in 2..5 {
                 s.push_str(&format!("alias {a}{n} = vec{n}<{t}>;\n"));
+            }
+        }
+        for n in 2..5 {
+            for m in 2..5 {
+                s.push_str(&format!("alias float{n}x{m} = mat{n}x{m}<f32>;\n"));
             }
         }
         s.push_str(


### PR DESCRIPTION
Adds the following type aliases to the prelude.
```wgsl
alias bool2 = vec2<bool>;
alias bool3 = vec3<bool>;
alias bool4 = vec4<bool>;
alias float2x2 = mat2x2<f32>;
alias float2x3 = mat2x3<f32>;
alias float2x4 = mat2x4<f32>;
alias float3x2 = mat3x2<f32>;
alias float3x3 = mat3x3<f32>;
alias float3x4 = mat3x4<f32>;
alias float4x2 = mat4x2<f32>;
alias float4x3 = mat4x3<f32>;
alias float4x4 = mat4x4<f32>;
```
Since `vecN<T>` requires `T` to be a concrete scalar, and `matNxM<T>` requires `T` to be a float, this new set of type aliases covers all possible use cases (with the exception of `f16`).

The downside is that some shaders already contain a subset of these aliases, meaning some shaders will break and need to be fixed manually. Though this should be a 5-second fix in most cases, and the impact of such a change would be a lot greater further down the line.