### PR TITLE
Handle updated framebuffer

### DIFF
--- a/src/bin/toy.rs
+++ b/src/bin/toy.rs
@@ -112,6 +112,14 @@ fn main() -> Result<(), Box<dyn Error>> {
                 position.y as f32 / screen_size.height as f32,
             ),
             winit::event::Event::WindowEvent {
+                event: winit::event::WindowEvent::Resized(size),
+                ..
+            } => {
+                if size.width != 0 && size.height != 0 {
+                    wgputoy.resize(size.width, size.height, 1.);
+                }
+            }
+            winit::event::Event::WindowEvent {
                 event: winit::event::WindowEvent::MouseInput { state, .. },
                 ..
             } => wgputoy.set_mouse_click(state == winit::event::ElementState::Pressed),


### PR DESCRIPTION
I wasn't able to run compute.toy on linux. Linux calls resizing immediately at the start of the program and invalidates current surface. 

With this PR I'm adding support for surface resizing. Out of GPU memory case is not handled. In native I'll just stop the main loop, but I don't know what to do in web (perhaps nothing, because it wasn't handled before either). 

```bash
[2023-05-07T17:54:16Z ERROR wgputoy] Unable to get framebuffer: The underlying surface has changed, and therefore the swap chain must be updated
```
I also changed a bit about how to choose the surface format. I give priority to `Rgba8Unorm` and `Bgra8Unorm` formats and store surface config instead of just surface format.