### PR TITLE
New blitter API

### DIFF
--- a/src/blit.wgsl
+++ b/src/blit.wgsl
@@ -1,58 +1,19 @@
-// https://github.com/gfx-rs/wgpu/blob/master/wgpu/examples/mipmap/blit.wgsl
-
 struct VertexOutput {
     @builtin(position) position: vec4<f32>,
-    @location(0) tex_coords: vec2<f32>
+    @location(0) tex_coords: vec2<f32>,
 };
 
 @vertex
-fn vs_main(@builtin(vertex_index) vertex_index: u32) -> VertexOutput {
-    var out: VertexOutput;
-    let x = i32(vertex_index) / 2;
-    let y = i32(vertex_index) & 1;
-    let tc = vec2<f32>(
-        f32(x) * 2.0,
-        f32(y) * 2.0
-    );
-    out.position = vec4<f32>(
-        tc.x * 2.0 - 1.0,
-        1.0 - tc.y * 2.0,
-        0.0, 1.0
-    );
-    out.tex_coords = tc;
-    return out;
+fn vs_main(@builtin(vertex_index) vertex_idx: u32) -> VertexOutput {
+    let uv = vec2(f32(vertex_idx & 2u), f32((vertex_idx << 1u) & 2u));
+    let pos = vec4(uv.x * 2.0 - 1.0, 1.0 - uv.y * 2.0, 0.0, 1.0);
+    return VertexOutput(pos, uv);
 }
 
-@group(0) @binding(0) var r_color: texture_2d<f32>;
-@group(0) @binding(1) var r_sampler: sampler;
-
-fn srgb_to_linear(rgb: vec3<f32>) -> vec3<f32> {
-    return select(
-        pow((rgb + 0.055) * (1.0 / 1.055), vec3<f32>(2.4)),
-        rgb * (1.0/12.92),
-        rgb <= vec3<f32>(0.04045));
-}
-
-fn linear_to_srgb(rgb: vec3<f32>) -> vec3<f32> {
-    return select(
-        1.055 * pow(rgb, vec3(1.0 / 2.4)) - 0.055,
-        rgb * 12.92,
-        rgb <= vec3<f32>(0.0031308));
-}
+@group(0) @binding(0) var tex: texture_2d<f32>;
+@group(0) @binding(1) var tex_sampler: sampler;
 
 @fragment
-fn fs_main(in: VertexOutput) -> @location(0) vec4<f32> {
-    return textureSample(r_color, r_sampler, in.tex_coords);
-}
-
-@fragment
-fn fs_main_linear_to_srgb(in: VertexOutput) -> @location(0) vec4<f32> {
-    let rgba = textureSample(r_color, r_sampler, in.tex_coords);
-    return vec4<f32>(linear_to_srgb(rgba.rgb), rgba.a);
-}
-
-@fragment
-fn fs_main_rgbe_to_linear(in: VertexOutput) -> @location(0) vec4<f32> {
-    let rgbe = textureSample(r_color, r_sampler, in.tex_coords);
-    return vec4<f32>(rgbe.rgb * exp2(rgbe.a * 255. - 128.), 1.);
+fn fs_main(vout: VertexOutput) -> @location(0) vec4<f32> {
+    return textureSample(tex, tex_sampler, vout.tex_coords);
 }

--- a/src/context.rs
+++ b/src/context.rs
@@ -147,7 +147,7 @@ fn preferred_framebuffer_format(formats: &[wgpu::TextureFormat]) -> wgpu::Textur
     for &format in formats {
         if matches!(
             format,
-            wgpu::TextureFormat::Rgba8Unorm | wgpu::TextureFormat::Bgra8Unorm
+            wgpu::TextureFormat::Rgba8UnormSrgb | wgpu::TextureFormat::Bgra8UnormSrgb
         ) {
             return format;
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,10 +12,7 @@ use std::collections::HashMap;
 use std::mem::{size_of, take};
 use std::sync::atomic::{AtomicBool, Ordering};
 use wasm_bindgen::prelude::*;
-<<<<<<< HEAD
-=======
 use wgpu::util::DeviceExt;
->>>>>>> 2fff1ec (Initial api draft)
 
 // When the `wee_alloc` feature is enabled, use `wee_alloc` as the global
 // allocator.


### PR DESCRIPTION
For now, it's just a draft to show current progress. I'm trying to figure out how conversions with texture views work and if is it possible to remove linear to srgb functions from shader.

Main work is going in this [repo](https://github.com/pudnax/blittin_test)

## Tests 

For first example I set surface format to `Bgra8UnormSrgb` and render png image on different viewports.
rows: 
ordinary draw | current blitter |new blitter
--- | --- | ---

columns: 
srgb tex   | srgb tex      | linr tex  | linr tex 
--- | --- | --- | ---
srgb view | linr view | srgb view | linr view
 

<img src="https://github.com/compute-toys/wgpu-compute-toy/assets/32329320/ef75893f-d6df-4417-8f30-6e350b5c6ee6" width="500" height="400">

Things are changing when I set surface format to `Bgra8Unorm`.

<img src="https://github.com/compute-toys/wgpu-compute-toy/assets/32329320/81af080f-e7f4-4610-ba1f-a5f13da1c2f6" width="500" height="400">

Current blitter doesn't depend on the texture format and converts color spaces automatically.

### Links

- [discussion](https://github.com/gpuweb/gpuweb/issues/386#issuecomment-1073571539) about implementing wgsl compute shaders for mipmapping 
- reference code for srgb conversions [link](https://github.com/MomentsInGraphics/vulkan_renderer/blob/main/src/shaders/srgb_utility.glsl)
