### PR TITLE
default mouse position in center of screen

### DIFF
--- a/src/bind.rs
+++ b/src/bind.rs
@@ -280,7 +280,7 @@ impl Bindings {
             },
             mouse: BufferBinding {
                 host: Mouse {
-                    pos: [0, 0],
+                    pos: [width / 2, height / 2],
                     click: 0,
                 },
                 serialise: Box::new(|h| bytemuck::bytes_of(h).to_vec()),


### PR DESCRIPTION
This is very useful for camera controls.

Examples:
https://compute.toys/view/31
https://compute.toys/view/459