### PR TITLE
allow spaces between storage type and size

### DIFF
--- a/examples/michael0884/variational-integrator.wgsl
+++ b/examples/michael0884/variational-integrator.wgsl
@@ -2,18 +2,13 @@
 
 #define LENGTH 256
 
-struct SimData
-{
-    data: array<array<float, LENGTH>,2>,
-}
-
-#storage sim SimData
+#storage sim_data array<array<float, LENGTH>, 2>
 
 #define IN_BUF (time.frame%2u)
 #define OUT_BUF ((time.frame+1u)%2u)
 
-fn Load(i: uint)  -> float     { return sim.data[IN_BUF][i];  }
-fn Store(i: uint, data: float) { sim.data[OUT_BUF][i] = data; }
+fn Load(i: uint)  -> float     { return sim_data[IN_BUF][i];  }
+fn Store(i: uint, data: float) { sim_data[OUT_BUF][i] = data; }
 
 fn sdSegment(p: float2, a: float2, b: float2) -> float
 {

--- a/src/pp.rs
+++ b/src/pp.rs
@@ -180,13 +180,14 @@ impl Preprocessor {
                     }
                     self.defines.insert(l.to_string(), r);
                 }
-                ["#storage", name, ty] => {
+                ["#storage", name, ref types @ ..] => {
                     if self.storage_count >= 2 {
                         return Err(WGSLError::new(
                             "Only two storage buffers are currently supported".to_string(),
                             n,
                         ));
                     }
+                    let ty = types.join(" ");
                     self.source.push_line(
                         &format!(
                             "@group(0) @binding({}) var<storage,read_write> {name}: {ty};",


### PR DESCRIPTION
Fix: https://github.com/compute-toys/compute.toys/issues/52