### PR TITLE
Migrate cargo config to config.toml

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,4 @@
+[build]
+rustflags = [
+    "--cfg=web_sys_unstable_apis",
+]

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,6 @@
 {
     //"rust-analyzer.cargo.target": "wasm32-unknown-unknown"
+    "rust-analyzer.runnableEnv": {
+        "RUSTFLAGS": "--cfg=web_sys_unstable_apis"
+    }
 }


### PR DESCRIPTION
Fix cargo warning
```
warning: `D:\Coding\GitHub\Libraries\compute.toys\wgpu-compute-toy\.cargo\config` is deprecated in favor of `config.toml`
note: if you need to support cargo 1.38 or earlier, you can symlink `config` to `config.toml`
```