### PR TITLE
Remove wee-alloc

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,12 +36,6 @@ indexmap = "1.9.3"
 # code size when deploying.
 console_error_panic_hook = { version = "0.1.7", optional = true }
 
-# `wee_alloc` is a tiny allocator for wasm that is only ~1K in code size
-# compared to the default allocator's ~10K. It is slower than the default
-# allocator, however.
-#
-# Unfortunately, `wee_alloc` requires nightly Rust when targeting wasm for now.
-wee_alloc = { version = "0.4.5", optional = true }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 console_log = "1.0.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,12 +14,6 @@ use std::mem::{size_of, take};
 use std::sync::atomic::{AtomicBool, Ordering};
 use wasm_bindgen::prelude::*;
 
-// When the `wee_alloc` feature is enabled, use `wee_alloc` as the global
-// allocator.
-#[cfg(feature = "wee_alloc")]
-#[global_allocator]
-static ALLOC: wee_alloc::WeeAlloc = wee_alloc::WeeAlloc::INIT;
-
 #[cfg(target_arch = "wasm32")]
 #[derive(Clone)]
 struct SuccessCallback(Option<js_sys::Function>);


### PR DESCRIPTION
Fix https://github.com/compute-toys/compute.toys/issues/74

I looked at the [talc benchmarks](https://github.com/SFBdragon/talc/blob/master/README_WASM.md#relative-wasm-binary-size), and figured that the default allocator isn't too bad.