### PR TITLE
Add optional extensions

### DIFF
--- a/src/context.rs
+++ b/src/context.rs
@@ -109,11 +109,15 @@ pub async fn init_wgpu(width: u32, height: u32, bind_id: &str) -> Result<WgpuCon
         })
         .await
         .ok_or("unable to create adapter")?;
+    
+    log::info!("adapter.limits = {:#?}", adapter.features());
+    log::info!("adapter.limits = {:#?}", adapter.limits());
+    
     let (device, queue) = adapter
         .request_device(
             &wgpu::DeviceDescriptor {
                 label: Some("GPU Device"),
-                required_features: adapter.features(),
+                required_features: wgpu::Features::empty(),// | adapter.features(),
                 required_limits: wgpu::Limits::default(),
             },
             None,
@@ -137,7 +141,6 @@ pub async fn init_wgpu(width: u32, height: u32, bind_id: &str) -> Result<WgpuCon
     };
     surface.configure(&device, &surface_config);
 
-    log::info!("adapter.limits = {:#?}", adapter.limits());
     Ok(WgpuContext {
         #[cfg(all(not(target_arch = "wasm32"), feature = "winit"))]
         event_loop: Some(event_loop),

--- a/src/context.rs
+++ b/src/context.rs
@@ -117,7 +117,7 @@ pub async fn init_wgpu(width: u32, height: u32, bind_id: &str) -> Result<WgpuCon
         .request_device(
             &wgpu::DeviceDescriptor {
                 label: Some("GPU Device"),
-                required_features: wgpu::Features::empty(),// | adapter.features(),
+                required_features: adapter.features(),
                 required_limits: wgpu::Limits::default(),
             },
             None,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -232,9 +232,7 @@ impl WgpuToyRenderer {
             if !p.dispatch_once || self.bindings.time.host.frame == 0 {
                 for i in 0..p.dispatch_count {
                     let mut compute_pass = encoder.begin_compute_pass(&Default::default());
-                    if let Some(q) = &self.query_set {
-                        compute_pass.write_timestamp(q, 2 * pass_index as u32);
-                    }
+                    // if let Some(q) = &self.query_set { compute_pass.write_timestamp(q, 2 * pass_index as u32); }
                     let workgroup_count = p.workgroup_count.unwrap_or([
                         self.screen_width.div_ceil(p.workgroup_size[0]),
                         self.screen_height.div_ceil(p.workgroup_size[1]),
@@ -257,9 +255,7 @@ impl WgpuToyRenderer {
                         workgroup_count[1],
                         workgroup_count[2],
                     );
-                    if let Some(q) = &self.query_set {
-                        compute_pass.write_timestamp(q, 2 * pass_index as u32 + 1);
-                    }
+                    // if let Some(q) = &self.query_set { compute_pass.write_timestamp(q, 2 * pass_index as u32 + 1); }
                     drop(compute_pass);
                     encoder.copy_texture_to_texture(
                         wgpu::ImageCopyTexture {
@@ -337,7 +333,7 @@ impl WgpuToyRenderer {
                 Some(Ok(())) => {
                     let data = buffer_slice.get_mapped_range();
                     let assertions: &[u32] = bytemuck::cast_slice(&data[0..ASSERTS_SIZE]);
-                    let _timestamps: &[u64] = bytemuck::cast_slice(&data[ASSERTS_SIZE..]);
+                    //let _timestamps: &[u64] = bytemuck::cast_slice(&data[ASSERTS_SIZE..]);
                     for (i, count) in assertions.iter().enumerate() {
                         if count > &0 {
                             let percent =
@@ -553,24 +549,12 @@ fn passSampleLevelBilinearRepeat(pass_index: int, uv: float2, lod: float) -> flo
                 ),
             })
             .collect();
-        self.query_set = if !self
-            .wgpu
-            .device
-            .features()
-            .contains(wgpu::Features::TIMESTAMP_QUERY)
-        {
-            None
-        } else {
-            Some(
-                self.wgpu
-                    .device
-                    .create_query_set(&wgpu::QuerySetDescriptor {
-                        label: None,
-                        count: 2 * self.compute_pipelines.len() as u32,
-                        ty: wgpu::QueryType::Timestamp,
-                    }),
-            )
-        };
+        // self.query_set = if !self.wgpu.device.features().contains(wgpu::Features::TIMESTAMP_QUERY) {
+        //     None
+        // } else {
+        //     Some(self.wgpu.device.create_query_set(&wgpu::QuerySetDescriptor {label: None,
+        //          count: 2 * self.compute_pipelines.len() as u32, ty: wgpu::QueryType::Timestamp,
+        // }),)};
         self.bindings.user_data.host = source.user_data.clone();
         log::info!(
             "Shader compiled in {}s",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -473,7 +473,7 @@ fn passSampleLevelBilinearRepeat(pass_index: int, uv: float2, lod: float) -> flo
 
     pub fn compile(&mut self, source: SourceMap) {
         let now = instant::Instant::now();
-        let prelude = self.prelude(); // prelude must be generated after preprocessor has run
+        let prelude = format!("{}{}", source.extensions, self.prelude());
 
         // FIXME: remove pending resolution of this issue: https://github.com/gfx-rs/wgpu/issues/2130
         let prelude_len = count_newlines(&prelude);


### PR DESCRIPTION
How to use [extensions](https://www.w3.org/TR/WGSL/#enable-extensions-sec):

```wgsl
enable chromium_experimental_subgroups;
#define PI 3.14

@compute @workgroup_size(256)
#workgroup_count main 256 1 1
fn main(
  @builtin(global_invocation_id) global_id : vec3u,
  @builtin(subgroup_size) sg_size : u32,
  @builtin(subgroup_invocation_id) sg_id : u32
) {
      // TODO: Use subgroupBallot() and subgroupBroadcast()
}
```

The problem that wgpu [not supporting chromium extension](https://github.com/gfx-rs/wgpu/issues/5685) yet, but maybe we create device with web_sys?

Also it seems some errors introduced to wasm build after [79ad98d](https://github.com/compute-toys/wgpu-compute-toy/tree/79ad98d7f3002615fb75e6a6d97133e9db56f054) commit, @stefnotch can you please fix it? It is visible only with compute.toy website.