### PR TITLE
Upgrade wgpu to 0.20.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -68,7 +68,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee91c0c2905bae44f84bfa4e044536541df26b7703fd0888deeb9060fcc44289"
 dependencies = [
  "android-properties",
- "bitflags 2.4.2",
+ "bitflags 2.6.0",
  "cc",
  "cesu8",
  "jni",
@@ -265,9 +265,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.4.2"
+version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed570934406eb16438a4e976b1b4500774099c13b8cb96eec99f620f05090ddf"
+checksum = "b048fb63fd8b5923fc5aa7b340d8e156aec7ec02f0c78fa8a6ddc2613f6f71de"
 
 [[package]]
 name = "bitvec"
@@ -421,7 +421,7 @@ version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fba7adb4dd5aa98e5553510223000e7148f621165ec5f9acd7113f6ca4995298"
 dependencies = [
- "bitflags 2.4.2",
+ "bitflags 2.6.0",
  "log",
  "polling",
  "rustix",
@@ -643,11 +643,11 @@ checksum = "96a6ac251f4a2aca6b3f91340350eab87ae57c3f127ffeb585e92bd336717991"
 
 [[package]]
 name = "d3d12"
-version = "0.19.0"
+version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e3d747f100290a1ca24b752186f61f6637e1deffe3bf6320de6fcb29510a307"
+checksum = "b28bfe653d79bd16c77f659305b195b82bb5ce0c0eb2a4846b82ddbd77586813"
 dependencies = [
- "bitflags 2.4.2",
+ "bitflags 2.6.0",
  "libloading 0.8.3",
  "winapi",
 ]
@@ -719,6 +719,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "330c60081dcc4c72131f8eb70510f1ac07223e5d4163db481a04a0befcffa412"
 dependencies = [
  "libloading 0.8.3",
+]
+
+[[package]]
+name = "document-features"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef5282ad69563b5fc40319526ba27e0e7363d552a896f0297d54f767717f9b95"
+dependencies = [
+ "litrs",
 ]
 
 [[package]]
@@ -1078,7 +1087,7 @@ version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fbcd2dba93594b227a1f57ee09b8b9da8892c34d55aa332e034a228d0fe6a171"
 dependencies = [
- "bitflags 2.4.2",
+ "bitflags 2.6.0",
  "gpu-alloc-types",
 ]
 
@@ -1088,7 +1097,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "98ff03b468aa837d70984d55f5d3f846f6ec31fe34bbb97c4f85219caeee1ca4"
 dependencies = [
- "bitflags 2.4.2",
+ "bitflags 2.6.0",
 ]
 
 [[package]]
@@ -1106,22 +1115,22 @@ dependencies = [
 
 [[package]]
 name = "gpu-descriptor"
-version = "0.2.4"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc11df1ace8e7e564511f53af41f3e42ddc95b56fd07b3f4445d2a6048bc682c"
+checksum = "9c08c1f623a8d0b722b8b99f821eb0ba672a1618f0d3b16ddbee1cedd2dd8557"
 dependencies = [
- "bitflags 2.4.2",
+ "bitflags 2.6.0",
  "gpu-descriptor-types",
  "hashbrown",
 ]
 
 [[package]]
 name = "gpu-descriptor-types"
-version = "0.1.2"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6bf0b36e6f090b7e1d8a4b49c0cb81c1f8376f72198c65dd3ad9ff3556b8b78c"
+checksum = "fdf242682df893b86f33a73828fb09ca4b2d3bb6cc95249707fc684d27484b91"
 dependencies = [
- "bitflags 2.4.2",
+ "bitflags 2.6.0",
 ]
 
 [[package]]
@@ -1159,7 +1168,7 @@ version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af2a7e73e1f34c48da31fb668a907f250794837e08faa144fd24f0b8b741e890"
 dependencies = [
- "bitflags 2.4.2",
+ "bitflags 2.6.0",
  "com",
  "libc",
  "libloading 0.8.3",
@@ -1527,7 +1536,7 @@ version = "0.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3af92c55d7d839293953fcd0fda5ecfe93297cfde6ffbdec13b41d99c0ba6607"
 dependencies = [
- "bitflags 2.4.2",
+ "bitflags 2.6.0",
  "libc",
  "redox_syscall 0.4.1",
 ]
@@ -1537,6 +1546,12 @@ name = "linux-raw-sys"
 version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "01cda141df6706de531b6c46c3a33ecca755538219bd484262fa09410c13539c"
+
+[[package]]
+name = "litrs"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4ce301924b7887e9d637144fdade93f9dfff9b60981d4ac161db09720d39aa5"
 
 [[package]]
 name = "lock_api"
@@ -1589,11 +1604,11 @@ dependencies = [
 
 [[package]]
 name = "metal"
-version = "0.27.0"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c43f73953f8cbe511f021b58f18c3ce1c3d1ae13fe953293e13345bf83217f25"
+checksum = "5637e166ea14be6063a3f8ba5ccb9a4159df7d8f6d61c02fc3d480b1f90dcfcb"
 dependencies = [
- "bitflags 2.4.2",
+ "bitflags 2.6.0",
  "block",
  "core-graphics-types",
  "foreign-types 0.5.0",
@@ -1664,12 +1679,13 @@ dependencies = [
 
 [[package]]
 name = "naga"
-version = "0.19.2"
+version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50e3524642f53d9af419ab5e8dd29d3ba155708267667c2f3f06c88c9e130843"
+checksum = "e536ae46fcab0876853bd4a632ede5df4b1c2527a58f6c5a4150fe86be858231"
 dependencies = [
+ "arrayvec",
  "bit-set",
- "bitflags 2.4.2",
+ "bitflags 2.6.0",
  "codespan-reporting",
  "hexf-parse",
  "indexmap",
@@ -1706,7 +1722,7 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2076a31b7010b17a38c01907c45b945e8f11495ee4dd588309718901b1f7a5b7"
 dependencies = [
- "bitflags 2.4.2",
+ "bitflags 2.6.0",
  "jni-sys",
  "log",
  "ndk-sys",
@@ -1849,7 +1865,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "915b1b472bc21c53464d6c8461c9d3af805ba1ef837e1cac254428f4a77177b1"
 dependencies = [
  "malloc_buf",
- "objc_exception",
 ]
 
 [[package]]
@@ -1875,15 +1890,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d079845b37af429bfe5dfa76e6d087d788031045b25cfc6fd898486fd9847666"
 
 [[package]]
-name = "objc_exception"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad970fb455818ad6cba4c122ad012fae53ae8b4795f86378bce65e4f6bab2ca4"
-dependencies = [
- "cc",
-]
-
-[[package]]
 name = "object"
 version = "0.32.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1904,7 +1910,7 @@ version = "0.10.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95a0481286a310808298130d22dd1fef0fa571e05a8f44ec801801e84b216b1f"
 dependencies = [
- "bitflags 2.4.2",
+ "bitflags 2.6.0",
  "cfg-if",
  "foreign-types 0.3.2",
  "libc",
@@ -2279,7 +2285,7 @@ version = "0.38.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ea3e1a662af26cd7a3ba09c0297a31af215563ecf42817c98df621387f4e949"
 dependencies = [
- "bitflags 2.4.2",
+ "bitflags 2.6.0",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -2488,7 +2494,7 @@ version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "922fd3eeab3bd820d76537ce8f582b1cf951eceb5475c28500c7457d9d17f53a"
 dependencies = [
- "bitflags 2.4.2",
+ "bitflags 2.6.0",
  "calloop",
  "calloop-wayland-source",
  "cursor-icon",
@@ -2542,7 +2548,7 @@ version = "0.3.0+sdk-1.3.268.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eda41003dc44290527a59b13432d4a0379379fa074b70174882adfbdfd917844"
 dependencies = [
- "bitflags 2.4.2",
+ "bitflags 2.6.0",
 ]
 
 [[package]]
@@ -2614,7 +2620,7 @@ version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "658bc6ee10a9b4fcf576e9b0819d95ec16f4d2c02d39fd83ac1c8789785c4a42"
 dependencies = [
- "bitflags 2.4.2",
+ "bitflags 2.6.0",
  "core-foundation",
  "system-configuration-sys",
 ]
@@ -2667,18 +2673,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.57"
+version = "1.0.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e45bcbe8ed29775f228095caf2cd67af7a4ccf756ebff23a306bf3e8b47b24b"
+checksum = "c546c80d6be4bc6a00c0f01730c08df82eaa7a7a61f11d656526506112cc1709"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.57"
+version = "1.0.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a953cb265bef375dae3de6663da4d3804eee9682ea80d8e2542529b73c531c81"
+checksum = "46c3384250002a6d5af4d114f2845d37b57521033f30d5c3f46c4d70e1197533"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3101,7 +3107,7 @@ version = "0.31.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "82fb96ee935c2cea6668ccb470fb7771f6215d1691746c2d896b447a00ad3f1f"
 dependencies = [
- "bitflags 2.4.2",
+ "bitflags 2.6.0",
  "rustix",
  "wayland-backend",
  "wayland-scanner",
@@ -3113,7 +3119,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "625c5029dbd43d25e6aa9615e88b829a5cad13b2819c4ae129fdbb7c31ab4c7e"
 dependencies = [
- "bitflags 2.4.2",
+ "bitflags 2.6.0",
  "cursor-icon",
  "wayland-backend",
 ]
@@ -3135,7 +3141,7 @@ version = "0.31.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f81f365b8b4a97f422ac0e8737c438024b5951734506b0e1d775c73030561f4"
 dependencies = [
- "bitflags 2.4.2",
+ "bitflags 2.6.0",
  "wayland-backend",
  "wayland-client",
  "wayland-scanner",
@@ -3147,7 +3153,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23803551115ff9ea9bce586860c5c5a971e360825a0309264102a9495a5ff479"
 dependencies = [
- "bitflags 2.4.2",
+ "bitflags 2.6.0",
  "wayland-backend",
  "wayland-client",
  "wayland-protocols",
@@ -3160,7 +3166,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ad1f61b76b6c2d8742e10f9ba5c3737f6530b4c243132c2a2ccc8aa96fe25cd6"
 dependencies = [
- "bitflags 2.4.2",
+ "bitflags 2.6.0",
  "wayland-backend",
  "wayland-client",
  "wayland-protocols",
@@ -3212,13 +3218,14 @@ dependencies = [
 
 [[package]]
 name = "wgpu"
-version = "0.19.3"
+version = "0.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4b1213b52478a7631d6e387543ed8f642bc02c578ef4e3b49aca2a29a7df0cb"
+checksum = "90e37c7b9921b75dfd26dd973fdcbce36f13dfa6e2dc82aece584e0ed48c355c"
 dependencies = [
  "arrayvec",
  "cfg-if",
  "cfg_aliases",
+ "document-features",
  "js-sys",
  "log",
  "naga",
@@ -3237,15 +3244,16 @@ dependencies = [
 
 [[package]]
 name = "wgpu-core"
-version = "0.19.3"
+version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9f6b033c2f00ae0bc8ea872c5989777c60bc241aac4e58b24774faa8b391f78"
+checksum = "d50819ab545b867d8a454d1d756b90cd5f15da1f2943334ca314af10583c9d39"
 dependencies = [
  "arrayvec",
  "bit-vec",
- "bitflags 2.4.2",
+ "bitflags 2.6.0",
  "cfg_aliases",
  "codespan-reporting",
+ "document-features",
  "indexmap",
  "log",
  "naga",
@@ -3263,15 +3271,15 @@ dependencies = [
 
 [[package]]
 name = "wgpu-hal"
-version = "0.19.3"
+version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49f972c280505ab52ffe17e94a7413d9d54b58af0114ab226b9fc4999a47082e"
+checksum = "172e490a87295564f3fcc0f165798d87386f6231b04d4548bca458cbbfd63222"
 dependencies = [
  "android_system_properties",
  "arrayvec",
  "ash",
  "bit-set",
- "bitflags 2.4.2",
+ "bitflags 2.6.0",
  "block",
  "cfg_aliases",
  "core-graphics-types",
@@ -3308,18 +3316,18 @@ dependencies = [
 
 [[package]]
 name = "wgpu-types"
-version = "0.19.2"
+version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b671ff9fb03f78b46ff176494ee1ebe7d603393f42664be55b64dc8d53969805"
+checksum = "1353d9a46bff7f955a680577f34c69122628cc2076e1d6f3a9be6ef00ae793ef"
 dependencies = [
- "bitflags 2.4.2",
+ "bitflags 2.6.0",
  "js-sys",
  "web-sys",
 ]
 
 [[package]]
 name = "wgputoy"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "async-recursion",
  "bitvec",
@@ -3650,7 +3658,7 @@ dependencies = [
  "ahash",
  "android-activity",
  "atomic-waker",
- "bitflags 2.4.2",
+ "bitflags 2.6.0",
  "bytemuck",
  "calloop",
  "cfg_aliases",
@@ -3761,7 +3769,7 @@ version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d039de8032a9a8856a6be89cea3e5d12fdd82306ab7c94d74e6deab2460651c5"
 dependencies = [
- "bitflags 2.4.2",
+ "bitflags 2.6.0",
  "dlib",
  "log",
  "once_cell",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,7 +54,7 @@ serde_json = "1.0"
 winit = { version = "0.29.14", optional = true }
 
 [dependencies.wgpu]
-version = "0.20.1"
+version = "0.20.0"
 
 [dependencies.image]
 version = "0.24.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wgputoy"
-version = "0.1.0"
+version = "0.1.1"
 authors = ["David A Roberts <d@vidr.cc>"]
 edition = "2021"
 
@@ -54,7 +54,7 @@ serde_json = "1.0"
 winit = { version = "0.29.14", optional = true }
 
 [dependencies.wgpu]
-version = "0.19.3"
+version = "0.20.1"
 
 [dependencies.image]
 version = "0.24.2"

--- a/src/blit.rs
+++ b/src/blit.rs
@@ -1,3 +1,5 @@
+use wgpu::PipelineCompilationOptions;
+
 use crate::context::WgpuContext;
 
 #[derive(Copy, Clone, Debug)]
@@ -78,6 +80,7 @@ impl Blitter {
                     module: &render_shader,
                     entry_point: "vs_main",
                     buffers: &[],
+                    compilation_options: PipelineCompilationOptions::default(),
                 },
                 fragment: Some(wgpu::FragmentState {
                     module: &render_shader,
@@ -92,6 +95,7 @@ impl Blitter {
                         _ => panic!("Blitter: unrecognised conversion from {src_space:?} to {dest_format:?}")
                     },
                     targets: &[Some(dest_format.into())],
+                    compilation_options: PipelineCompilationOptions::default(),
                 }),
                 primitive: wgpu::PrimitiveState::default(),
                 depth_stencil: None,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,6 +9,7 @@ use context::init_wgpu;
 use context::WgpuContext;
 use lazy_regex::regex;
 use pp::{SourceMap, WGSLError};
+use wgpu::PipelineCompilationOptions;
 use std::collections::HashMap;
 use std::mem::{size_of, take};
 use std::sync::atomic::{AtomicBool, Ordering};
@@ -553,6 +554,7 @@ fn passSampleLevelBilinearRepeat(pass_index: int, uv: float2, lod: float) -> flo
                         layout: Some(&self.compute_pipeline_layout),
                         module: &compute_shader,
                         entry_point: &entry_point.0,
+                        compilation_options: PipelineCompilationOptions::default(),
                     },
                 ),
             })


### PR DESCRIPTION
Currently running wgpu-compute-toy on macOS fails to compile shaders.

For instance the buddhabrot example fails with the following:
```
[2024-07-03T17:19:59Z ERROR wgpu::backend::wgpu_core] Shader translation error for stage ShaderStages(COMPUTE): Metal: program_source:81:5: error: too many arguments provided to function-like macro invocation
        bool success,
        ^
    /System/Library/PrivateFrameworks/GPUCompiler.framework/Versions/32023/Libraries/lib/clang/32023.194/include/metal/metal_assert:19:9: note: macro 'assert' defined here
    #define assert(condition) ((void) 0)
            ^
    program_source:79:6: error: program scope variable must reside in constant address space
    void assert(
         ^
    program_source:85:5: error: expected expression
        if (!(success)) {
        ^
    program_source:91:2: error: expected ';' after top level declarator
    }
     ^
     ;
    program_source:245:29: warning: unused variable '_e205' [-Wunused-variable]
                            int _e205 = uint(_e202) < 1 + (_buffer_sizes.size18 - 0 - 4) / 4 ? metal::atomic_fetch_add_explicit(&atomic_storage[_e202], 1, metal::memory_order_relaxed) : DefaultConstructible();
                                ^
    program_source:247:29: warning: unused variable '_e213' [-Wunused-variable]
                            int _e213 = uint(_e210) < 1 + (_buffer_sizes.size18 - 0 - 4) / 4 ? metal::atomic_fetch_add_explicit(&atomic_storage[_e210], 1, metal::memory_order_relaxed) : DefaultConstructible();
                                ^
    program_source:252:33: warning: unused variable '_e224' [-Wunused-variable]
                                int _e224 = uint(_e221) < 1 + (_buffer_sizes.size18 - 0 - 4) / 4 ? metal::atomic_fetch_add_explicit(&atomic_storage[_e221], 1, metal::memory_order_relaxed) : DefaultConstructible();
                                    ^
    program_source:254:33: warning: unused variable '_e232' [-Wunused-variable]
                                int _e232 = uint(_e229) < 1 + (_buffer_sizes.size18 - 0 - 4) / 4 ? metal::atomic_fetch_add_explicit(&atomic_storage[_e229], 1, metal::memory_order_relaxed) : DefaultConstructible();
                                    ^
    program_source:259:37: warning: unused variable '_e243' [-Wunused-variable]
                                    int _e243 = uint(_e240) < 1 + (_buffer_sizes.size18 - 0 - 4) / 4 ? metal::atomic_fetch_add_explicit(&atomic_storage[_e240], 1, metal::memory_order_relaxed) : DefaultConstructible();
                                        ^
    program_source:261:37: warning: unused variable '_e251' [-Wunused-variable]
                                    int _e251 = uint(_e248) < 1 + (_buffer_sizes.size18 - 0 - 4) / 4 ? metal::atomic_fetch_add_explicit(&atomic_storage[_e248], 1, metal::memory_order_relaxed) : DefaultConstructible();
                                        ^
                                                                                                                                            
[2024-07-03T17:19:59Z ERROR wgpu::backend::wgpu_core] Please report it to https://github.com/gfx-rs/wgpu
[2024-07-03T17:19:59Z ERROR wgputoy] Validation Error
                                                                                                                                            
    Caused by:
        In Device::create_compute_pipeline
        Internal error: Metal: program_source:81:5: error: too many arguments provided to function-like macro invocation
        bool success,
        ^
    /System/Library/PrivateFrameworks/GPUCompiler.framework/Versions/32023/Libraries/lib/clang/32023.194/include/metal/metal_assert:19:9: note: macro 'assert' defined here
    #define assert(condition) ((void) 0)
            ^
    program_source:79:6: error: program scope variable must reside in constant address space
    void assert(
         ^
    program_source:85:5: error: expected expression
        if (!(success)) {
        ^
    program_source:91:2: error: expected ';' after top level declarator
    }
     ^
     ;
    program_source:245:29: warning: unused variable '_e205' [-Wunused-variable]
                            int _e205 = uint(_e202) < 1 + (_buffer_sizes.size18 - 0 - 4) / 4 ? metal::atomic_fetch_add_explicit(&atomic_storage[_e202], 1, metal::memory_order_relaxed) : DefaultConstructible();
                                ^
    program_source:247:29: warning: unused variable '_e213' [-Wunused-variable]
                            int _e213 = uint(_e210) < 1 + (_buffer_sizes.size18 - 0 - 4) / 4 ? metal::atomic_fetch_add_explicit(&atomic_storage[_e210], 1, metal::memory_order_relaxed) : DefaultConstructible();
                                ^
    program_source:252:33: warning: unused variable '_e224' [-Wunused-variable]
                                int _e224 = uint(_e221) < 1 + (_buffer_sizes.size18 - 0 - 4) / 4 ? metal::atomic_fetch_add_explicit(&atomic_storage[_e221], 1, metal::memory_order_relaxed) : DefaultConstructible();
                                    ^
    program_source:254:33: warning: unused variable '_e232' [-Wunused-variable]
                                int _e232 = uint(_e229) < 1 + (_buffer_sizes.size18 - 0 - 4) / 4 ? metal::atomic_fetch_add_explicit(&atomic_storage[_e229], 1, metal::memory_order_relaxed) : DefaultConstructible();
                                    ^
    program_source:259:37: warning: unused variable '_e243' [-Wunused-variable]
                                    int _e243 = uint(_e240) < 1 + (_buffer_sizes.size18 - 0 - 4) / 4 ? metal::atomic_fetch_add_explicit(&atomic_storage[_e240], 1, metal::memory_order_relaxed) : DefaultConstructible();
                                        ^
    program_source:261:37: warning: unused variable '_e251' [-Wunused-variable]
                                    int _e251 = uint(_e248) < 1 + (_buffer_sizes.size18 - 0 - 4) / 4 ? metal::atomic_fetch_add_explicit(&atomic_storage[_e248], 1, metal::memory_order_relaxed) : DefaultConstructible();
                                        ^
                                                                                                                                            
                                                                                                                                            
thread 'main' panicked at src/pp.rs:29:9:
0:0: Validation Error
                                                                                                                                            
Caused by:
    In Device::create_compute_pipeline
    Internal error: Metal: program_source:81:5: error: too many arguments provided to function-like macro invocation
    bool success,
    ^
/System/Library/PrivateFrameworks/GPUCompiler.framework/Versions/32023/Libraries/lib/clang/32023.194/include/metal/metal_assert:19:9: note: macro 'assert' defined here
#define assert(condition) ((void) 0)
        ^
program_source:79:6: error: program scope variable must reside in constant address space
void assert(
     ^
program_source:85:5: error: expected expression
    if (!(success)) {
    ^
program_source:91:2: error: expected ';' after top level declarator
}
 ^
 ;
program_source:245:29: warning: unused variable '_e205' [-Wunused-variable]
                        int _e205 = uint(_e202) < 1 + (_buffer_sizes.size18 - 0 - 4) / 4 ? metal::atomic_fetch_add_explicit(&atomic_storage[_e202], 1, metal::memory_order_relaxed) : DefaultConstructible();
                            ^
program_source:247:29: warning: unused variable '_e213' [-Wunused-variable]
                        int _e213 = uint(_e210) < 1 + (_buffer_sizes.size18 - 0 - 4) / 4 ? metal::atomic_fetch_add_explicit(&atomic_storage[_e210], 1, metal::memory_order_relaxed) : DefaultConstructible();
                            ^
program_source:252:33: warning: unused variable '_e224' [-Wunused-variable]
                            int _e224 = uint(_e221) < 1 + (_buffer_sizes.size18 - 0 - 4) / 4 ? metal::atomic_fetch_add_explicit(&atomic_storage[_e221], 1, metal::memory_order_relaxed) : DefaultConstructible();
                                ^
program_source:254:33: warning: unused variable '_e232' [-Wunused-variable]
                            int _e232 = uint(_e229) < 1 + (_buffer_sizes.size18 - 0 - 4) / 4 ? metal::atomic_fetch_add_explicit(&atomic_storage[_e229], 1, metal::memory_order_relaxed) : DefaultConstructible();
                                ^
program_source:259:37: warning: unused variable '_e243' [-Wunused-variable]
                                int _e243 = uint(_e240) < 1 + (_buffer_sizes.size18 - 0 - 4) / 4 ? metal::atomic_fetch_add_explicit(&atomic_storage[_e240], 1, metal::memory_order_relaxed) : DefaultConstructible();
                                    ^
program_source:261:37: warning: unused variable '_e251' [-Wunused-variable]
                                int _e251 = uint(_e248) < 1 + (_buffer_sizes.size18 - 0 - 4) / 4 ? metal::atomic_fetch_add_explicit(&atomic_storage[_e248], 1, metal::memory_order_relaxed) : DefaultConstructible();
                                    ^


note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

Upgrading wgpu to 0.20.0 correctly compiles and runs:
![image](https://github.com/compute-toys/wgpu-compute-toy/assets/39032044/bbc3e9d0-c774-45b9-bf29-5ffcf836c03b)

_NOTE_ - 0.20.1 also works but I assume it would not be a good idea to upgrade to that as it's not completely finished.